### PR TITLE
fix: teach bara.py what to do if branches are added

### DIFF
--- a/bara.py
+++ b/bara.py
@@ -9,18 +9,16 @@ from pprint import pprint
 files = sys.argv[1:]
 
 ts = {}
-prev_names = None
+names = []
 for f in files:
     print(f)
     ts[f] = uproot.open(f)["events"]
-    names = set([b.name for b in ts[f].branches])
+    names.append(set([b.name for b in ts[f].branches]))
 
-    if prev_names is not None:
-        print(deepdiff.DeepDiff(prev_names, names))
+    if len(names) > 1:
+        print(deepdiff.DeepDiff(names[-2], names[-1]))
 
-    prev_names = names
-
-#for b in sorted(names):
+#for b in sorted(set.intersection(*names)):
 #    for l in [b.name for b in ts[f][b].branches]:
 #        print(b, l)
 #        #for f in files:
@@ -37,7 +35,7 @@ for f in files:
 
 t1 = ts[files[0]]
 t2 = ts[files[1]]
-for b in sorted(names):
+for b in sorted(set.intersection(*names)):
     if b == "PARAMETERS": continue
     #print("b:", b)
     b1 = t1[b]


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Previously, the `names` of the last file were used when getting the uproot arrays, even if those names were not present in the first file. This runs the array diff only over the intersection of all files.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: bara.py fails to handle added branches, e.g. https://github.com/eic/EICrecon/actions/runs/5701665646/job/15452716874?pr=807#step:10:72)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes, only intersection of all branches will be diffed (in practice no behavior change).