### PR TITLE
add .github/workflows/build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,17 @@
+name: "Test capybara installation"
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build and install epic-capybara
+        run: |
+          pip install hatch
+          hatch build
+          pip install dist/*.whl


### PR DESCRIPTION
If we want to enable hatching capybara on EICrecon CI, would be nice to test that it's installable upstream.