### PR TITLE
feat: print KS p-value

### DIFF
--- a/epic_capybara/cli/bara.py
+++ b/epic_capybara/cli/bara.py
@@ -9,6 +9,7 @@ from bokeh.io import curdoc
 from bokeh.layouts import gridplot
 from bokeh.plotting import figure, output_file, save
 from hist import Hist
+from scipy.stats import kstest
 
 from ..util import skip_common_prefix
 
@@ -116,8 +117,12 @@ def bara(files, match, unmatch, serve):
                              != ak.num(prev_file_arr, axis=1))
                    or ak.any(ak.nan_to_none(file_arr)
                              != ak.nan_to_none(prev_file_arr))):
+                    pvalue = kstest(
+                            ak.to_numpy(ak.flatten(file_arr)),
+                            ak.to_numpy(ak.flatten(prev_file_arr))
+                        ).pvalue
                     print(key)
-                    print(prev_file_arr, file_arr)
+                    print(prev_file_arr, file_arr, f"p = {pvalue:.3f}")
                     collection_with_diffs.add(key.split("/")[0])
             prev_file_arr = file_arr
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
   "hist",
   "PyGithub",
   "requests",
+  "scipy",
   "uproot",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Prints two-side K-S test p-value at end of diff line (p-values of zero are just very small numbers):
```
CentralCKFTrackParameters#0/CentralCKFTrackParameters#0.collectionID
[[-2, -2, -2, -2, -2, -2, -2, -2, -2, -2], ..., [-2, -2, -2, ..., -2, -2, -2]] [[-2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2], ..., [-2, ...]] p = 1.000
CentralCKFTrackParameters#0/CentralCKFTrackParameters#0.index
[[-2, -2, -2, -2, -2, -2, -2, -2, -2, -2], ..., [-2, -2, -2, ..., -2, -2, -2]] [[-2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2], ..., [-2, ...]] p = 1.000
CentralCKFTrackParameters/CentralCKFTrackParameters.charge
[[-1, 1, -1, 1, -1, 1, 1, 1, -1, 1], ..., [1, -1, 1, -1, 1, ..., -1, -1, 1, -1]] [[-1, 1, 1, -1, -1, -1, 1, -1, 1, 1, 1, -1, 1, 1, 1], ..., [1, -1, ..., 1, -1]] p = 1.000
CentralCKFTrackParameters/CentralCKFTrackParameters.loc.a
[[0.0398, 0.0286, 0.135, 0.337, ..., 11.3, -0.0209, -0.223, 13.7], ..., [...]] [[0.0134, 0.028, 0.0279, 0.0134, 0.136, ..., -0.223, 14.2, 14.3, 14.3], ...] p = 0.038
CentralCKFTrackParameters/CentralCKFTrackParameters.loc.b
[[-37.8, -37.8, -38.6, -36.7, -37.8, -38, 108, -26, -57.9, 150], ..., [...]] [[-37.8, -37.9, -37.9, -37.8, -38.7, ..., -28.7, -57.8, 195, 195, 195], ...] p = 0.243
CentralCKFTrackParameters/CentralCKFTrackParameters.locError.xx
[[0.000142, 0.000215, 0.00593, 0.0475, ..., 0.966, 1.08, 0.139, 0.937], ...] [[5.06e-05, 7.76e-05, 7.76e-05, 5.06e-05, ..., 0.139, 2.47, 2.45, 2.45], ...] p = 0.000
```

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.