### PR TITLE
fix: only run KS test when both data sets have entries

### DIFF
--- a/epic_capybara/cli/bara.py
+++ b/epic_capybara/cli/bara.py
@@ -117,10 +117,13 @@ def bara(files, match, unmatch, serve):
                              != ak.num(prev_file_arr, axis=1))
                    or ak.any(ak.nan_to_none(file_arr)
                              != ak.nan_to_none(prev_file_arr))):
-                    pvalue = kstest(
-                            ak.to_numpy(ak.flatten(file_arr)),
-                            ak.to_numpy(ak.flatten(prev_file_arr))
-                        ).pvalue
+                    if ak.num(file_arr, axis=0) > 0 and ak.num(prev_file_arr, axis=0) > 0:
+                        pvalue = kstest(
+                                ak.to_numpy(ak.flatten(file_arr)),
+                                ak.to_numpy(ak.flatten(prev_file_arr))
+                            ).pvalue
+                    else:
+                        pvalue = 0
                     print(key)
                     print(prev_file_arr, file_arr, f"p = {pvalue:.3f}")
                     collection_with_diffs.add(key.split("/")[0])


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This fix should avoid errors (https://github.com/eic/EICrecon/actions/runs/6960649502/job/18941744946?pr=865#step:9:1940) with message
```
ValueError: Data passed to ks_2samp must not be empty
```
If the data is absent in one case, the p-value is definitely 0. You could argue that when the data is absent in both cases, then the p-value is 1, but that's probably pathological enough not to worry about it.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.