### PR TITLE
fix: one more KS-test fix (ak.flatten before ak.num)

### DIFF
--- a/epic_capybara/cli/bara.py
+++ b/epic_capybara/cli/bara.py
@@ -117,7 +117,9 @@ def bara(files, match, unmatch, serve):
                              != ak.num(prev_file_arr, axis=1))
                    or ak.any(ak.nan_to_none(file_arr)
                              != ak.nan_to_none(prev_file_arr))):
-                    if ak.num(file_arr, axis=0) > 0 and ak.num(prev_file_arr, axis=0) > 0:
+                    if (ak.num(ak.flatten(file_arr), axis=0) > 0 and
+                        ak.num(ak.flatten(prev_file_arr), axis=0) > 0):
+                        # We can only apply the KS test on non-empty arrays
                         pvalue = kstest(
                                 ak.to_numpy(ak.flatten(file_arr)),
                                 ak.to_numpy(ak.flatten(prev_file_arr))


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Let's try again to address the ValueError (i.e. fixes #9), and now by `ak.flatten`. I couldn't reproduce the issue in the EICrecon CI pipelines because I have the `ak.flatten` in my local copy, so I'm pretty sure this is the fix. Also:
```python
jug_xl> wdconinc@menelaos:~/git/epic-capybara$ python
Python 3.10.10 (main, Jul 11 2023, 18:58:24) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import awkward as ak
>>> array = ak.Array([[],[],[]])
>>> array
<Array [[], [], []] type='3 * var * unknown'>
>>> ak.num(array, axis=0)
3
>>> ak.num(ak.flatten(array), axis=0)
0
```

### What kind of change does this PR introduce?
- [x] Bug fix (issue #9)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.