### PR TITLE
feat: add error bars to plots, confidence levels to legend, stars to dropdown

### DIFF
--- a/epic_capybara/cli/bara.py
+++ b/epic_capybara/cli/bara.py
@@ -129,6 +129,8 @@ def bara(files, match, unmatch, serve):
                 line_dash=line_dash,
             )
 
+            # diff and KS test
+            pvalue = None
             if prev_file_arr is not None:
                 if ((ak.num(file_arr, axis=0) != ak.num(prev_file_arr, axis=0))
                    or ak.any(ak.num(file_arr, axis=1)
@@ -146,7 +148,7 @@ def bara(files, match, unmatch, serve):
                         pvalue = 0
                     print(key)
                     print(prev_file_arr, file_arr, f"p = {pvalue:.3f}")
-                    collection_with_diffs[branch_name] = pvalue
+                    collection_with_diffs[branch_name] = min(pvalue, collection_with_diffs.get(branch_name, 1.))
 
             y_max = max(y_max, np.max(y0 + np.sqrt(y0)))
             prev_file_arr = file_arr

--- a/epic_capybara/cli/bara.py
+++ b/epic_capybara/cli/bara.py
@@ -99,16 +99,16 @@ def bara(files, match, unmatch, serve):
 
         prev_file_arr = None
         vis_params = [
-          ("green", 1.5, "solid"),
-          ("red", 3, "dashed"),
-          ("blue", 2, "dotted"),
+          ("green", 1.5, "solid", " "),
+          ("red", 3, "dashed", ","),
+          ("blue", 2, "dotted", "."),
         ]
 
         if set(arr[key].keys()) != set(files):
             # not every file has the key
             collection_with_diffs[branch_name] = 0.0
 
-        for _file, label, (color, line_width, line_dash) in zip(files, labels, vis_params):
+        for _file, label, (color, line_width, line_dash, hatch_pattern) in zip(files, labels, vis_params):
             if _file not in arr[key]:
                 continue
             file_arr = arr[key][_file]

--- a/epic_capybara/cli/bara.py
+++ b/epic_capybara/cli/bara.py
@@ -154,6 +154,19 @@ def bara(files, match, unmatch, serve):
                 line_width=line_width,
                 line_dash=line_dash,
             )
+            fig.varea_step(
+                x=edges + x_min,
+                y1=y0 - np.sqrt(y0),
+                y2=y0 + np.sqrt(y0),
+                step_mode="after",
+                legend_label=legend_label,
+                fill_color=color if hatch_pattern == " " else None,
+                fill_alpha=0.25,
+                hatch_color=color,
+                hatch_alpha=0.5,
+                hatch_pattern=hatch_pattern,
+            )
+
             y_max = max(y_max, np.max(y0 + np.sqrt(y0)))
             prev_file_arr = file_arr
 

--- a/epic_capybara/cli/bara.py
+++ b/epic_capybara/cli/bara.py
@@ -112,22 +112,6 @@ def bara(files, match, unmatch, serve):
             if _file not in arr[key]:
                 continue
             file_arr = arr[key][_file]
-            h = (
-                Hist.new
-                .Reg(nbins, 0, x_range, name="x", label=key)
-                .Int64()
-            )
-            h.fill(x=ak.flatten(file_arr - x_min, axis=None))
-
-            ys, edges = h.to_numpy()
-            fig.step(
-                edges + x_min, np.concatenate([ys, [ys[-1]]]),
-                mode="after",
-                legend_label=label,
-                line_color=color,
-                line_width=line_width,
-                line_dash=line_dash,
-            )
 
             # diff and KS test
             pvalue = None
@@ -150,6 +134,26 @@ def bara(files, match, unmatch, serve):
                     print(prev_file_arr, file_arr, f"p = {pvalue:.3f}")
                     collection_with_diffs[branch_name] = min(pvalue, collection_with_diffs.get(branch_name, 1.))
 
+            # Figure
+            h = (
+                Hist.new
+                .Reg(nbins, 0, x_range, name="x", label=key)
+                .Int64()
+            )
+            h.fill(x=ak.flatten(file_arr - x_min, axis=None))
+
+            ys, edges = h.to_numpy()
+            y0 = np.concatenate([ys, [ys[-1]]])
+            legend_label=label + (f"\n{100*pvalue:.0f}%CL KS" if pvalue is not None else "")
+            fig.step(
+                x=edges + x_min,
+                y=y0,
+                mode="after",
+                legend_label=legend_label,
+                line_color=color,
+                line_width=line_width,
+                line_dash=line_dash,
+            )
             y_max = max(y_max, np.max(y0 + np.sqrt(y0)))
             prev_file_arr = file_arr
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adds a few new interrelated features to assess more easily where the significant differences are:
- depending on the confidence level of the KS test, we use no star (identical), * (> 99%CL statistically equivalent), ** (> 95%CL), *** (> 67%CL), and **** (< 67% CL),
- the confidence level of the KS test is added to the legend of plotted branches,
- the bin uncertainties (assumed sqrt(n)) are added as shaded or hatched bands,
- the bounds of the plotting canvas are locked to 10% larger than where data is, so one cannot scroll completely away from the data.

Looks like this now:
![image](https://github.com/user-attachments/assets/fdc0da6b-a71c-498f-ae36-d2f08174da44)

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes.