### PR TITLE
bara: add protection against overflows before setting Range1d

### DIFF
--- a/epic_capybara/cli/bara.py
+++ b/epic_capybara/cli/bara.py
@@ -175,10 +175,14 @@ def bara(files, match, unmatch, serve):
             fig.x_range = Range1d(
                 *x_bounds,
                 bounds=x_bounds)
+        else:
+            click.secho(f"overflow while calculating x bounds for \"{key}\"", fg="red",  err=True)
         if np.all(np.isfinite(y_bounds)):
             fig.y_range = Range1d(
                 *y_bounds,
                 bounds=y_bounds)
+        else:
+            click.secho(f"overflow while calculating y bounds for \"{key}\"", fg="red", err=True)
 
     def to_filename(branch_name):
         return branch_name.replace("#", "__pound__")

--- a/epic_capybara/cli/bara.py
+++ b/epic_capybara/cli/bara.py
@@ -171,12 +171,14 @@ def bara(files, match, unmatch, serve):
         x_bounds = (x_min - 0.05 * x_range, x_min + 1.05 * x_range)
         y_bounds = (- 0.05 * y_max, 1.05 * y_max)
         # Set y range for histograms
-        fig.x_range = Range1d(
-            *x_bounds,
-            bounds=x_bounds)
-        fig.y_range = Range1d(
-            *y_bounds,
-            bounds=y_bounds)
+        if np.all(np.isfinite(x_bounds)):
+            fig.x_range = Range1d(
+                *x_bounds,
+                bounds=x_bounds)
+        if np.all(np.isfinite(y_bounds)):
+            fig.y_range = Range1d(
+                *y_bounds,
+                bounds=y_bounds)
 
     def to_filename(branch_name):
         return branch_name.replace("#", "__pound__")


### PR DESCRIPTION
Trying to address latest failures on EICrecon main branch that I can not reproduce locally.
https://github.com/eic/EICrecon/actions/runs/10603480392/job/29389189840#step:16:2287