### PR TITLE
Allow axis ranges smaller than 1

### DIFF
--- a/epic_capybara/cli/bara.py
+++ b/epic_capybara/cli/bara.py
@@ -10,6 +10,7 @@ from bokeh.events import DocumentReady
 from bokeh.io import curdoc
 from bokeh.layouts import gridplot
 from bokeh.models import Range1d
+from bokeh.models import PrintfTickFormatter
 from bokeh.plotting import figure, output_file, save
 from hist import Hist
 from scipy.stats import kstest
@@ -82,7 +83,10 @@ def bara(files, match, unmatch, serve):
         x_range = max(filter(
             lambda v: v is not None,
             map(lambda a: ak.max(ak.mask(a - x_min, np.isfinite(a))), arr[key].values())
-        ), default=None) + 1
+        ), default=None)
+        
+        if x_range == 0 or x_range is None:
+            x_range = 1
 
         nbins = 10
         if (any("* uint" in str(ak.type(a)) for a in arr[key].values())
@@ -96,6 +100,7 @@ def bara(files, match, unmatch, serve):
             leaf_name = key
 
         fig = figure(x_axis_label=leaf_name, y_axis_label="Entries")
+        fig.xaxis.formatter = PrintfTickFormatter(format="%.1e")
         collection_figs.setdefault(branch_name, []).append(fig)
         y_max = 0
 

--- a/epic_capybara/cli/bara.py
+++ b/epic_capybara/cli/bara.py
@@ -103,7 +103,8 @@ def bara(files, match, unmatch, serve):
             leaf_name = key
 
         fig = figure(x_axis_label=leaf_name, y_axis_label="Entries")
-        fig.xaxis.formatter = PrintfTickFormatter(format="%.2g")
+        if x_range < 1.:
+            fig.xaxis.formatter = PrintfTickFormatter(format="%.2g")
         collection_figs.setdefault(branch_name, []).append(fig)
         y_max = 0
 

--- a/epic_capybara/cli/bara.py
+++ b/epic_capybara/cli/bara.py
@@ -84,14 +84,16 @@ def bara(files, match, unmatch, serve):
             lambda v: v is not None,
             map(lambda a: ak.max(ak.mask(a - x_min, np.isfinite(a))), arr[key].values())
         ), default=None)
-        
-        if x_range == 0 or x_range is None:
-            x_range = 1
-
         nbins = 10
         if (any("* uint" in str(ak.type(a)) for a in arr[key].values())
            or any("* int" in str(ak.type(a)) for a in arr[key].values())):
+            x_range = x_range + 1
             nbins = int(min(100, np.ceil(x_range)))
+        else:
+            x_range = x_range*1.1
+
+        if x_range == 0 or x_range is None:
+            x_range = 1
 
         if "/" in key:
             branch_name, leaf_name = key.split("/", 1)

--- a/epic_capybara/cli/bara.py
+++ b/epic_capybara/cli/bara.py
@@ -90,9 +90,9 @@ def bara(files, match, unmatch, serve):
             x_range = x_range + 1
             nbins = int(min(100, np.ceil(x_range)))
         else:
-            x_range = x_range*1.1
+            x_range = x_range * 1.1
 
-        if x_range == 0 or x_range is None:
+        if x_range == 0:
             x_range = 1
 
         if "/" in key:

--- a/epic_capybara/cli/bara.py
+++ b/epic_capybara/cli/bara.py
@@ -86,9 +86,8 @@ def bara(files, match, unmatch, serve):
         ), default=None)
         nbins = 10
 
-        is_int = (any("* uint" in str(ak.type(a)) for a in arr[key].values())
-           or any("* int" in str(ak.type(a)) for a in arr[key].values()))
-        if is_int:
+        if (any("* uint" in str(ak.type(a)) for a in arr[key].values())
+           or any("* int" in str(ak.type(a)) for a in arr[key].values())):
             x_range = x_range + 1
             nbins = int(min(100, np.ceil(x_range)))
         else:
@@ -104,8 +103,7 @@ def bara(files, match, unmatch, serve):
             leaf_name = key
 
         fig = figure(x_axis_label=leaf_name, y_axis_label="Entries")
-        if not is_int:
-            fig.xaxis.formatter = PrintfTickFormatter(format="%.1e")
+        fig.xaxis.formatter = PrintfTickFormatter(format="%.2g")
         collection_figs.setdefault(branch_name, []).append(fig)
         y_max = 0
 

--- a/epic_capybara/cli/bara.py
+++ b/epic_capybara/cli/bara.py
@@ -85,8 +85,10 @@ def bara(files, match, unmatch, serve):
             map(lambda a: ak.max(ak.mask(a - x_min, np.isfinite(a))), arr[key].values())
         ), default=None)
         nbins = 10
-        if (any("* uint" in str(ak.type(a)) for a in arr[key].values())
-           or any("* int" in str(ak.type(a)) for a in arr[key].values())):
+
+        is_int = (any("* uint" in str(ak.type(a)) for a in arr[key].values())
+           or any("* int" in str(ak.type(a)) for a in arr[key].values()))
+        if is_int:
             x_range = x_range + 1
             nbins = int(min(100, np.ceil(x_range)))
         else:
@@ -102,7 +104,8 @@ def bara(files, match, unmatch, serve):
             leaf_name = key
 
         fig = figure(x_axis_label=leaf_name, y_axis_label="Entries")
-        fig.xaxis.formatter = PrintfTickFormatter(format="%.1e")
+        if not is_int:
+            fig.xaxis.formatter = PrintfTickFormatter(format="%.1e")
         collection_figs.setdefault(branch_name, []).append(fig)
         y_max = 0
 
@@ -175,6 +178,7 @@ def bara(files, match, unmatch, serve):
                 hatch_alpha=0.5,
                 hatch_pattern=hatch_pattern,
             )
+            fig.legend.background_fill_alpha = 0.5 # make legend more transparent
 
             y_max = max(y_max, np.max(y0 + np.sqrt(y0)))
             prev_file_arr = file_arr


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Allows the range of the x axis of capybara plots to go bellow 1 so that the details changes in small ranges become visible.
e.g. from https://github.com/eic/EICrecon/pull/1763

Current:
![image](https://github.com/user-attachments/assets/9083d25b-1d5f-47b8-b310-09772bf1f140)

New:
![image](https://github.com/user-attachments/assets/4731116f-2880-4ad8-aa32-e1dc8555dc60)

### What kind of change does this PR introduce?
- [x] Bug fix (issue #22 )
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
Changes the axis range for small data ranges and changes the formatting so that the values are all visible.