### PR TITLE
feat: sort by event number for reduced changesets

### DIFF
--- a/epic_capybara/cli/bara.py
+++ b/epic_capybara/cli/bara.py
@@ -60,8 +60,14 @@ def bara(files, match, unmatch, serve):
             and len(tree[key].branches) == 0
             and match_filter(key, match, unmatch)
         ]
+
+        sort_by_evtnum = None
+        if "EventHeader.eventNumber" in keys:
+            evtnum = tree["EventHeader.eventNumber"].array()
+            sort_by_evtnum = ak.argsort(ak.flatten(evtnum))
+
         for key in keys:
-            arr.setdefault(key, {})[_file] = tree[key].array()
+            arr.setdefault(key, {})[_file] = tree[key].array(evtnum) if sort_by_evtnum is None else tree[key].array()[sort_by_evtnum]
 
     paths = skip_common_prefix([_file.name.split("/") for _file in files])
     paths = skip_common_prefix([reversed(list(path)) for path in paths])

--- a/epic_capybara/cli/bara.py
+++ b/epic_capybara/cli/bara.py
@@ -54,17 +54,18 @@ def bara(files, match, unmatch, serve):
 
     for _file in files:
         tree = uproot.open(_file)["events"]
+
+        sort_by_evtnum = None
+        if "EventHeader/EventHeader.eventNumber" in tree.keys(recursive=True):
+            evtnum = tree["EventHeader/EventHeader.eventNumber"].array()
+            sort_by_evtnum = ak.argsort(ak.flatten(evtnum))
+
         keys = [
             key for key in tree.keys(recursive=True)
             if not key.startswith("PARAMETERS")
             and len(tree[key].branches) == 0
             and match_filter(key, match, unmatch)
         ]
-
-        sort_by_evtnum = None
-        if "EventHeader.eventNumber" in keys:
-            evtnum = tree["EventHeader.eventNumber"].array()
-            sort_by_evtnum = ak.argsort(ak.flatten(evtnum))
 
         for key in keys:
             arr.setdefault(key, {})[_file] = tree[key].array(evtnum) if sort_by_evtnum is None else tree[key].array()[sort_by_evtnum]

--- a/epic_capybara/cli/bara.py
+++ b/epic_capybara/cli/bara.py
@@ -68,7 +68,7 @@ def bara(files, match, unmatch, serve):
         ]
 
         for key in keys:
-            arr.setdefault(key, {})[_file] = tree[key].array(evtnum) if sort_by_evtnum is None else tree[key].array()[sort_by_evtnum]
+            arr.setdefault(key, {})[_file] = tree[key].array() if sort_by_evtnum is None else tree[key].array()[sort_by_evtnum]
 
     paths = skip_common_prefix([_file.name.split("/") for _file in files])
     paths = skip_common_prefix([reversed(list(path)) for path in paths])

--- a/epic_capybara/cli/bara.py
+++ b/epic_capybara/cli/bara.py
@@ -68,7 +68,10 @@ def bara(files, match, unmatch, serve):
         ]
 
         for key in keys:
-            arr.setdefault(key, {})[_file] = tree[key].array() if sort_by_evtnum is None else tree[key].array()[sort_by_evtnum]
+            val = tree[key].array()
+            if sort_by_evtnum is not None:
+                val = val[sort_by_evtnum]
+            arr.setdefault(key, {})[_file] = val
 
     paths = skip_common_prefix([_file.name.split("/") for _file in files])
     paths = skip_common_prefix([reversed(list(path)) for path in paths])


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR introduces sorting of arrays by event number (from EventHeader, if present) to reduce the collections that are marked as not identical (but only due to ordering). 

This PR changes the list of one-star collections in a comparison between 8 and 16 threaded running from basically all collections:
![image](https://github.com/user-attachments/assets/49cf12dd-e618-4c3a-9af5-03987cdf0f6b)
to only half of the collections
![image](https://github.com/user-attachments/assets/de68face-1f98-4028-b5fb-311402710f28)

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: collections marked as different when only order is different)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes, sorting is applied by default when an `EventHeader.eventNumber` collection is present.