### PR TITLE
perf: reduce per-figure Bokeh model overhead in `.json.gz` files

### DIFF
--- a/epic_capybara/cli/bara.py
+++ b/epic_capybara/cli/bara.py
@@ -152,7 +152,8 @@ def bara(files, match, unmatch, serve):
             branch_name = key
             leaf_name = key
 
-        fig = figure(x_axis_label=leaf_name, y_axis_label="Entries")
+        fig = figure(x_axis_label=leaf_name, y_axis_label="Entries",
+                     tools="pan,wheel_zoom,reset,save")
         if x_range < 1.:
             fig.xaxis.formatter = PrintfTickFormatter(format="%.2g")
         collection_figs.setdefault(branch_name, []).append(fig)
@@ -206,7 +207,7 @@ def bara(files, match, unmatch, serve):
             ys, edges = h.to_numpy()
             y0 = np.concatenate([ys, [ys[-1]]])
             legend_label=label + (f"\n{100*pvalue:.0f}%CL KS" if pvalue is not None else "")
-            fig.step(
+            step_r = fig.step(
                 x=edges + x_min,
                 y=y0,
                 mode="after",
@@ -215,7 +216,8 @@ def bara(files, match, unmatch, serve):
                 line_width=line_width,
                 line_dash=line_dash,
             )
-            fig.varea_step(
+            step_r.nonselection_glyph = step_r.glyph
+            varea_r = fig.varea_step(
                 x=edges + x_min,
                 y1=y0 - np.sqrt(y0),
                 y2=y0 + np.sqrt(y0),
@@ -227,6 +229,7 @@ def bara(files, match, unmatch, serve):
                 hatch_alpha=0.5,
                 hatch_pattern=hatch_pattern,
             )
+            varea_r.nonselection_glyph = varea_r.glyph
             fig.legend.background_fill_alpha = 0.5 # make legend more transparent
 
             y_max = max(y_max, np.max(y0 + np.sqrt(y0)))


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Two independent optimizations that together cut each per-collection `.json.gz` file by ~21% on top of the options-list fix:

1. Remove BoxZoomTool per figure (`tools='pan,wheel_zoom,reset,save`) Each figure previously received the default Bokeh toolbar, which includes a BoxZoomTool together with a BoxAnnotation, BoxInteractionHandles, and AreaVisuals. These are serialized once per figure (~1,800 bytes each). With gridplot `merge_tools=True` those objects are replicated for every histogram in the collection. Wheel zoom covers the same use-case for 1D histograms.

2. Share nonselection_glyph with glyph on each renderer Bokeh auto-creates a separate nonselection_glyph for every GlyphRenderer (the dim version shown when another element is selected). Since no selection tools are present in the toolbar, this state is never reached. Setting `renderer.nonselection_glyph = renderer.glyph` makes both attributes reference the same object; Bokeh then serializes it once and emits a short id-reference (~30 bytes) for the second occurrence instead of a full duplicate (~280 bytes on average).

### What kind of change does this PR introduce?
- [x] Bug fix (issue: output json largely redundant)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.