### PR TITLE
fix: lazy-load GitHub dependencies

### DIFF
--- a/epic_capybara/cli/capy.py
+++ b/epic_capybara/cli/capy.py
@@ -1,7 +1,19 @@
 import click
-from github import Auth, Github, GithubException
 
-from ..github import download_artifact
+
+def _load_github_dependencies(ctx: click.Context):
+    try:
+        from github import Auth, Github, GithubException
+        from ..github import download_artifact
+    except ModuleNotFoundError as e:
+        click.secho(
+            "The `capy` commands require optional GitHub dependencies that are "
+            f"not importable in this Python environment: {e}.",
+            fg="red",
+            err=True,
+        )
+        ctx.exit(1)
+    return Auth, Github, GithubException, download_artifact
 
 
 @click.command()
@@ -12,6 +24,7 @@ from ..github import download_artifact
 @click.argument('pr_number', type=int)
 @click.pass_context
 def pr(ctx: click.Context, artifact_name: str, owner: str, pr_number: int, repo: str, token: str):
+    Auth, Github, GithubException, download_artifact = _load_github_dependencies(ctx)
     gh = Github(auth=Auth.Token(token))
     repo = gh.get_user(owner).get_repo(repo)
 
@@ -84,6 +97,7 @@ def pr(ctx: click.Context, artifact_name: str, owner: str, pr_number: int, repo:
 @click.argument('ref', type=str)
 @click.pass_context
 def rev(ctx: click.Context, artifact_name: str, owner: str, ref: str, repo: str, token: str):
+    Auth, Github, GithubException, download_artifact = _load_github_dependencies(ctx)
     gh = Github(auth=Auth.Token(token))
     repo = gh.get_user(owner).get_repo(repo)
 

--- a/epic_capybara/cli/cate.py
+++ b/epic_capybara/cli/cate.py
@@ -1,6 +1,5 @@
 import shutil
 import subprocess
-from github import Auth, Github, GithubException
 from pathlib import Path
 
 import click
@@ -10,6 +9,20 @@ from ..filesystem import hashdir
 from ..util import get_cache_dir
 
 
+def _load_github_dependencies(ctx: click.Context):
+    try:
+        from github import Auth, Github, GithubException
+    except ModuleNotFoundError as e:
+        click.secho(
+            "The `cate` command requires optional GitHub dependencies that are "
+            f"not importable in this Python environment: {e}.",
+            fg="red",
+            err=True,
+        )
+        ctx.exit(1)
+    return Auth, Github, GithubException
+
+
 @click.command()
 @click.option('--token', envvar="GITHUB_TOKEN", required=True, help="GitHub access token (defaults to GITHUB_TOKEN environment variable)")
 @click.option('--owner', help="Owner of the target repository (token owner by default)")
@@ -17,6 +30,7 @@ from ..util import get_cache_dir
 @click.argument('report-dir', type=click.Path(exists=True, file_okay=False, dir_okay=True))
 @click.pass_context
 def cate(ctx: click.Context, owner: str, repo: str, report_dir: str, token: str):
+    Auth, Github, GithubException = _load_github_dependencies(ctx)
     gh = Github(auth=Auth.Token(token))
 
     if owner is not None:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
In python 3.14, we lose the `cgi` builtin module. As long a pygithub appears to use this, I'm going to lazy-load GitHub dependencies for the CLI commands that need it only.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.