### PR TITLE
fix: add rntuple extra requiring uproot>=5.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,11 @@ dependencies = [
 ]
 dynamic = ["version"]
 
+[project.optional-dependencies]
+rntuple = [
+  "uproot>=5.7.0",
+]
+
 [project.urls]
 Documentation = "https://github.com/eic/epic-capybara#readme"
 Issues = "https://github.com/eic/epic-capybara/issues"


### PR DESCRIPTION
## Problem

EICrecon PR [eic/EICrecon#2469](https://github.com/eic/EICrecon/pull/2469) converts CI output files from TTree to RNTuple format (by passing `-Ppodio:output_backend=rntuple` to eicrecon). The capybara comparison step then fails with:

```
TypeError: size of array (0) is less than size of form (100)
```

## Root Cause

Files written by ROOT 6.38.00 use **RNTuple binary format version 1.0.1.0** (EPOCH.MAJOR.MINOR.PATCH). The eic-shell nightly container includes **uproot 5.6.3**, which — even with the eic-spack patches that add v1.0.1.0 footer support — has a bug in its array reading code path.

### What the eic-spack patches fix (but are not enough)

The eic-spack package applies two patches to uproot 5.5.2–5.7.1:
1. **`88e69d47`**: Support v1.0.1.0 footer ("linked attribute set" record frame) — this allows the file to be opened and its keys listed correctly.
2. **`ee1b1d55`**: Fix `_from_zigzag` to apply bit shift on unsigned integers.

These patches are already in the CI container. The footer parses correctly. **`tree.keys()` works. The failure happens when reading actual array data.**

### The actual bug: `read_col_pages` in uproot 5.6.3

When reading arrays (`tree[key].array()`), uproot 5.6.3 uses `read_col_pages()` in `models/RNTuple.py` via `_arrays()` in `behaviors/RNTuple.py`. For certain column configurations in v1.0.1.0 files (e.g., collections that are empty for all events in a cluster, or specific column representation layouts introduced by the ROOT 6.38.00 writer), `read_col_pages()` returns an empty buffer.

When this empty buffer is passed to `awkward.from_buffers(form, length=100, container_dict)`, it raises:
```
TypeError: size of array (0) is less than size of form (100)
```

### The fix in uproot 5.7.0

uproot 5.7.0 completely rewrote the RNTuple array reading code, replacing `read_col_pages()` with `read_cluster_range()`. This new implementation correctly handles all column configurations in v1.0.1.0 files. The old `read_col_pages` function was removed entirely.

## Changes

**Optional `rntuple` extra in `pyproject.toml`**: Add `uproot>=5.7.0` as an optional extra (`pip install epic-capybara[rntuple]`) rather than a hard dependency. The core capybara functionality only requires `uproot` (any version); the stricter version bound is only needed for reading RNTuple files written with ROOT 6.38.00+.

## Related PRs

- EICrecon PR: [eic/EICrecon#2469](https://github.com/eic/EICrecon/pull/2469) — the RNTuple output PR that exposes this issue
- Containers PR: [eic/containers#243](https://github.com/eic/containers/pull/243) — upgrades uproot in eic-shell nightly to 5.7.1
