### PR TITLE
feat: rework output of arrays when differerent

### DIFF
--- a/epic_capybara/cli/bara.py
+++ b/epic_capybara/cli/bara.py
@@ -204,8 +204,9 @@ def bara(files, match, unmatch, serve):
                             ).pvalue
                     else:
                         pvalue = 0
-                    print(key)
-                    print(prev_file_arr, file_arr, f"p = {pvalue:.3f}")
+                    print(key, f"p = {pvalue:.3f}")
+                    print(prev_file_arr)
+                    print(file_arr)
                     collection_with_diffs[branch_name] = min(pvalue, collection_with_diffs.get(branch_name, 1.))
 
             # Figure


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR refactors print statements for clarity. Instead of
```
SiBarrelHits.cellID
[[89753421954969915, 144679662776263228], [...], ..., [158559519591375163, ...]] [[89753421954969915, 144679662776263228], ..., [213691313252491579, ...]] p = 0.134
```
this will now print
```
SiBarrelHits.cellID p = 0.134
[[89753421954969915, 144679662776263228], [...], ..., [158559519591375163, ...]]
[[89753421954969915, 144679662776263228], ..., [213691313252491579, ...]]
```
which is easier to parse visually.

### What is the urgency of this PR?
- [ ] High
- [ ] Medium
- [x] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: QoL improvement on console output)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [x] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.

I think there may be one or two scripts that parse for `p = 0\..*` and that may now fail or print incorrect lines.