### PR TITLE
capy: avoid printing service messages to stdout

### DIFF
--- a/epic_capybara/cli/capy.py
+++ b/epic_capybara/cli/capy.py
@@ -1,3 +1,5 @@
+import sys
+
 import click
 from github import Auth, Github, GithubException
 
@@ -42,6 +44,7 @@ def pr(ctx: click.Context, artifact_name: str, owner: str, pr_number: int, repo:
             repo.get_workflow_runs(),
             label="Loading workflows",
             item_show_func=item_show_func,
+            file=sys.stderr,
     ) as workflows_bar:
         for workflow in workflows_bar:
             # workflow.head_commit.sha is not available, so we take the latest
@@ -101,6 +104,7 @@ def rev(ctx: click.Context, artifact_name: str, owner: str, ref: str, repo: str,
             repo.get_workflow_runs(),
             label="Loading workflows",
             item_show_func=item_show_func,
+            file=sys.stderr,
     ) as workflows_bar:
         for workflow in workflows_bar:
             # workflow.head_commit.sha is not available, so we take the latest

--- a/epic_capybara/cli/capy.py
+++ b/epic_capybara/cli/capy.py
@@ -69,8 +69,8 @@ def pr(ctx: click.Context, artifact_name: str, owner: str, pr_number: int, repo:
     for message in messages:
         click.secho(**message)
 
-    click.echo(f"PR base workflow: {workflow_base.html_url}")
-    click.echo(f"PR head workflow: {workflow_head.html_url}")
+    click.echo(f"PR base workflow: {workflow_base.html_url}", err=True)
+    click.echo(f"PR head workflow: {workflow_head.html_url}", err=True)
 
     click.echo(download_artifact(workflow_base, artifact_name, token=token, click=click))
     click.echo(download_artifact(workflow_head, artifact_name, token=token, click=click))
@@ -120,7 +120,7 @@ def rev(ctx: click.Context, artifact_name: str, owner: str, ref: str, repo: str,
     for message in messages:
         click.secho(**message)
 
-    click.echo(f"PR head workflow: {workflow_head.html_url}")
+    click.echo(f"PR head workflow: {workflow_head.html_url}", err=True)
 
     click.echo(download_artifact(workflow_head, artifact_name, token=token, click=click))
 


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.

The progress bar and some other messages currently end up in stdout preventing one from trivially getting downloaded filename.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.
  claude