### PR TITLE
Fix client-side sort order for p-value columns in summary table

### DIFF
--- a/epic_capybara/cli/bara.py
+++ b/epic_capybara/cli/bara.py
@@ -401,6 +401,26 @@ def bara(files, match, unmatch, serve):
         options.append((to_filename(collection_name), collection_name + marker))
 
     from bokeh.models import CustomJS, Select, DataTable, TableColumn, HTMLTemplateFormatter, NumberFormatter, StringFormatter
+    from bokeh.models.comparisons import CustomJSCompare
+
+    _ks_sorter = CustomJSCompare(code="""
+        if (x === '' && y === '') return 0;
+        if (x === '') return 1;
+        if (y === '') return -1;
+        const nx = parseFloat(x), ny = parseFloat(y);
+        return nx < ny ? -1 : nx > ny ? 1 : 0;
+    """)
+
+    _ad_sorter = CustomJSCompare(code="""
+        if (x === '' && y === '') return 0;
+        if (x === '') return 1;
+        if (y === '') return -1;
+        if (x === 'n/a' && y === 'n/a') return 0;
+        if (x === 'n/a') return 1;
+        if (y === 'n/a') return -1;
+        const nx = parseFloat(x), ny = parseFloat(y);
+        return nx < ny ? -1 : nx > ny ? 1 : 0;
+    """)
 
     def mk_summary_table():
         rows = []
@@ -454,8 +474,8 @@ def bara(files, match, unmatch, serve):
         right_num = NumberFormatter(text_align="right")
         columns = [
             TableColumn(field="collection", title="Collection", formatter=link_fmt, width=500),
-            TableColumn(field="ks_pvalue", title="min KS p-value", formatter=right_str, width=120),
-            TableColumn(field="ad_pvalue", title="min AD p-value", formatter=right_str, width=120),
+            TableColumn(field="ks_pvalue", title="min KS p-value", formatter=right_str, width=120, sorter=_ks_sorter),
+            TableColumn(field="ad_pvalue", title="min AD p-value", formatter=right_str, width=120, sorter=_ad_sorter),
             TableColumn(field="nmatch", title="# matching", formatter=right_num, width=80),
             TableColumn(field="ndiff", title="# differing", formatter=right_num, width=80),
             TableColumn(field="nplots", title="# plots", formatter=right_num, width=80),

--- a/epic_capybara/cli/bara.py
+++ b/epic_capybara/cli/bara.py
@@ -403,6 +403,8 @@ def bara(files, match, unmatch, serve):
     from bokeh.models import CustomJS, Select, DataTable, TableColumn, HTMLTemplateFormatter, NumberFormatter, StringFormatter
     from bokeh.models.comparisons import CustomJSCompare
 
+    # BokehJS creates the comparator as new Function("x", "y", ..., code),
+    # so the cell values are available as `x` and `y` in the snippet.
     _ks_sorter = CustomJSCompare(code="""
         if (x === '' && y === '') return 0;
         if (x === '') return 1;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
   "awkward",
-  "bokeh>=3.0.0",
+  "bokeh>=3.6.0",
   "click",
   "hist",
   "PyGithub",


### PR DESCRIPTION
## Summary

Fixes #45.

When the user clicks the **"min KS p-value"** or **"min AD p-value"** column headers in the summary `DataTable` to re-sort, the default string comparison caused `""` (absent p-value — perfect match) to sort **before** `"0.000"` (p=0, maximally different). This is semantically backwards.

## Fix

Added `CustomJSCompare` sorters to the two `TableColumn` objects inside `mk_summary_table()`, giving correct ascending sort order:

| Value | Meaning | Sort position |
|---|---|---|
| `"0.000"` – `"1.000"` | Numeric p-value | Ascending (0 first) |
| `"n/a"` | AD test not applicable | After all numerics |
| `""` | Absent (perfect match) | Last |

No changes to data storage, display formatting, initial sort order, or `option_key` (dropdown).

## Implementation

Uses Bokeh 3.x `TableColumn.sorter = CustomJSCompare(code=...)` — the supported API for per-column custom sort comparators, wired directly into SlickGrid's column definition.